### PR TITLE
Patch 1 - Small formatting change to assist external .md parsers to work better with <script> entries

### DIFF
--- a/Instructions/Labs/Lab05/Lab05-Extending-Office-lab-answer-key/05-Exercise-4-Understanding-actionable-messages.md
+++ b/Instructions/Labs/Lab05/Lab05-Extending-Office-lab-answer-key/05-Exercise-4-Understanding-actionable-messages.md
@@ -124,7 +124,7 @@ Because the card JSON must be wrapped in a `<script>` tag, the body of the actio
     }
     ```
 
-1. Wrap the resulting JSON in a ``<script>`` tag of type `application/adaptivecard+json`. If you are using the [legacy message card format](https://docs.microsoft.com/en-us/outlook/actionable-messages/message-card-reference) rather than the Adaptive card format, the <script> tag type MUST be `application/ld+json`.
+1. Wrap the resulting JSON in a `<script>` tag of type `application/adaptivecard+json`. If you are using the [legacy message card format](https://docs.microsoft.com/en-us/outlook/actionable-messages/message-card-reference) rather than the Adaptive card format, the `<script>` tag type MUST be `application/ld+json`.
 
     ```json
     <script type="application/adaptivecard+json">{

--- a/Instructions/Labs/Lab05/Lab05-Extending-Office-lab-instructions/05-Exercise-4-Understanding-actionable-messages.md
+++ b/Instructions/Labs/Lab05/Lab05-Extending-Office-lab-instructions/05-Exercise-4-Understanding-actionable-messages.md
@@ -124,7 +124,7 @@ Because the card JSON must be wrapped in a `<script>` tag, the body of the actio
     }
     ```
 
-1. Wrap the resulting JSON in a ``<script>`` tag of type `application/adaptivecard+json`. If you are using the [legacy message card format](https://docs.microsoft.com/en-us/outlook/actionable-messages/message-card-reference) rather than the Adaptive card format, the <script> tag type MUST be `application/ld+json`.
+1. Wrap the resulting JSON in a `<script>` tag of type `application/adaptivecard+json`. If you are using the [legacy message card format](https://docs.microsoft.com/en-us/outlook/actionable-messages/message-card-reference) rather than the Adaptive card format, the `<script>` tag type MUST be `application/ld+json`.
 
     ```json
     <script type="application/adaptivecard+json">{


### PR DESCRIPTION
# Module: 05
## Lab/Demo: 05
Exercise 4
Fixes # .

Changes proposed in this pull request:
In both Lab 5 Student & LAK documents, Exercise 4 has 2 <script> entries, one with double apostrophes, and one with no apostrophes.  When an ALH markdown parse tries to parse this, it fails.  In this case it can be fixed, by wrapping both <script> entries in a single '