### PR TITLE
Section 4, Lab 5, Exercise 1 - getQueryVariable

### DIFF
--- a/Instructions/Labs/4-Develop apps for Microsoft Teams/05-Collect input with task modules/01-Exercise-Collecting user input with task modules.md
+++ b/Instructions/Labs/4-Develop apps for Microsoft Teams/05-Collect input with task modules/01-Exercise-Collecting user input with task modules.md
@@ -400,8 +400,20 @@ Add the following code to the page. Most of this code mirrors what you would see
 import * as React from "react";
 import { Provider, Flex, Text, Button, Header, Input } from "@fluentui/react-northstar";
 import { useState, useEffect } from "react";
-import { useTeams, getQueryVariable } from "msteams-react-base-component";
+import { useTeams } from "msteams-react-base-component";
 import * as microsoftTeams from "@microsoft/teams-js";
+
+const getQueryVariable = (variable: string): string | undefined => {
+  const query = window.location.search.substring(1);
+  const vars = query.split("&");
+  for (const varPairs of vars) {
+      const pair = varPairs.split("=");
+      if (decodeURIComponent(pair[0]) === variable) {
+          return decodeURIComponent(pair[1]);
+      }
+  }
+  return undefined;
+};
 
 export const VideoSelectorTaskModule = () => {
 


### PR DESCRIPTION
ms-teams-react-base-component no longer exports a function for getQueryVariable. This places that function in the example directly, instead of using the no longer available library function.

# Module: 4
## Lab/Demo: 05